### PR TITLE
Add configurable metric registry and dynamic analytics handling

### DIFF
--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,73 +1,46 @@
-import type { TrendDirection, AnalyzedMetricKey, FrontendMetricId } from '@/types/analytics';
-
-// Metric mapping between frontend IDs and backend keys
-const METRIC_MAPPING: Record<FrontendMetricId, AnalyzedMetricKey> = {
-  'emotional_response': 'sentiment',
-  'message_clarity': 'message_clarity',
-  'brand_trust': 'trust_in_brand',
-  'intent_to_action': 'purchase_intent',
-  'key_concerns': 'key_concerns'
-};
-
-const REVERSE_METRIC_MAPPING: Record<string, FrontendMetricId> = {
-  'sentiment': 'emotional_response',
-  'message_clarity': 'message_clarity',
-  'trust_in_brand': 'brand_trust',
-  'purchase_intent': 'intent_to_action',
-  'key_concerns': 'key_concerns',
-  'key_concern_flagged': 'key_concerns'
-};
+import type { TrendDirection } from '@/types/analytics'
+import { metricRegistry, mapBackendMetricToFrontend, mapFrontendMetricToBackend, normalizeBackendMetricKey, getMetricByBackendKey } from './metricsRegistry'
 
 /**
  * Maps a frontend metric ID to the corresponding backend metric key
  */
-export function mapFrontendMetricToBackend(frontendId: FrontendMetricId): AnalyzedMetricKey {
-  return METRIC_MAPPING[frontendId] || frontendId as AnalyzedMetricKey;
+export { mapFrontendMetricToBackend, mapBackendMetricToFrontend, normalizeBackendMetricKey }
+
+export function getMetricLabelFromBackendKey(backendKey: string): string {
+  const metric = getMetricByBackendKey(backendKey)
+  return metric?.label || backendKey.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())
 }
 
-/**
- * Maps a backend metric key to the corresponding frontend metric ID
- */
-export function mapBackendMetricToFrontend(backendKey: string): FrontendMetricId | string {
-  return REVERSE_METRIC_MAPPING[backendKey] || backendKey;
+export function getMetricScale(backendKey: string): { min: number; max: number } | undefined {
+  return getMetricByBackendKey(backendKey)?.scale
 }
 
-/**
- * Normalizes metric key to handle both naming conventions
- */
-export function normalizeMetricKey(metric: string): string {
-  // Map common variations to canonical form
-  const normalized: Record<string, string> = {
-    'emotional_response': 'sentiment',
-    'brand_trust': 'trust_in_brand',
-    'intent_to_action': 'purchase_intent',
-    'key_concern_flagged': 'key_concerns'
-  };
-  return normalized[metric] || metric;
+export function listSentimentBackends(): string[] {
+  return metricRegistry.filter((metric) => metric.type === 'sentiment').flatMap((metric) => metric.backendKeys)
 }
 
 export function computeScoreColor(score: number, max: number = 10): string {
-  const percentage = (score / max) * 100;
-  if (percentage >= 70) return 'text-emerald-600';
-  if (percentage >= 40) return 'text-amber-600';
-  return 'text-red-600';
+  const percentage = (score / max) * 100
+  if (percentage >= 70) return 'text-emerald-600'
+  if (percentage >= 40) return 'text-amber-600'
+  return 'text-red-600'
 }
 
 export function computeScoreProgress(score: number, max: number = 10): number {
-  return (score / max) * 100;
+  return (score / max) * 100
 }
 
 export function getTrendFromScore(score: number, threshold: number): TrendDirection {
-  if (score > threshold) return 'up';
-  if (score < threshold) return 'down';
-  return 'neutral';
+  if (score > threshold) return 'up'
+  if (score < threshold) return 'down'
+  return 'neutral'
 }
 
 export function getSentimentDescriptor(sentiment: number): {
-  level: 'Positive' | 'Neutral' | 'Negative';
-  color: string;
-  badgeClassName: string;
-  iconTone: 'up' | 'down' | 'neutral';
+  level: 'Positive' | 'Neutral' | 'Negative'
+  color: string
+  badgeClassName: string
+  iconTone: 'up' | 'down' | 'neutral'
 } {
   if (sentiment > 0.2) {
     return {
@@ -75,7 +48,7 @@ export function getSentimentDescriptor(sentiment: number): {
       color: 'text-emerald-600',
       badgeClassName: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
       iconTone: 'up',
-    };
+    }
   }
   if (sentiment < -0.2) {
     return {
@@ -83,12 +56,12 @@ export function getSentimentDescriptor(sentiment: number): {
       color: 'text-red-600',
       badgeClassName: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
       iconTone: 'down',
-    };
+    }
   }
   return {
     level: 'Neutral',
     color: 'text-gray-600',
     badgeClassName: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300',
     iconTone: 'neutral',
-  };
+  }
 }

--- a/frontend/src/lib/metricsRegistry.ts
+++ b/frontend/src/lib/metricsRegistry.ts
@@ -1,0 +1,124 @@
+import { Brain, MessageSquare, Shield, Target, AlertCircle } from "lucide-react"
+import type { AnalyzedMetricKey, FrontendMetricId } from "@/types/analytics"
+import type { LucideIcon } from "lucide-react"
+
+type MetricKind = "score" | "sentiment" | "flag"
+
+export interface MetricDefinition {
+  id: FrontendMetricId | string
+  backendKeys: AnalyzedMetricKey[]
+  label: string
+  description: string
+  type: MetricKind
+  scale: { min: number; max: number }
+  defaultSelected?: boolean
+  defaultWeight?: number
+  icon?: { component: LucideIcon; color: string; bgColor: string }
+}
+
+export const metricRegistry: MetricDefinition[] = [
+  {
+    id: "emotional_response",
+    backendKeys: ["sentiment", "emotional_response"],
+    label: "Emotional Response",
+    description: "Primary emotional reaction and sentiment toward messaging",
+    type: "sentiment",
+    scale: { min: -1, max: 1 },
+    defaultSelected: true,
+    defaultWeight: 1,
+    icon: {
+      component: Brain,
+      color: "text-violet-600",
+      bgColor: "bg-violet-100 dark:bg-violet-900/30",
+    },
+  },
+  {
+    id: "message_clarity",
+    backendKeys: ["message_clarity"],
+    label: "Message Clarity",
+    description: "How well they understand the key messages",
+    type: "score",
+    scale: { min: 0, max: 10 },
+    defaultSelected: true,
+    defaultWeight: 1,
+    icon: {
+      component: MessageSquare,
+      color: "text-blue-600",
+      bgColor: "bg-blue-100 dark:bg-blue-900/30",
+    },
+  },
+  {
+    id: "brand_trust",
+    backendKeys: ["trust_in_brand", "brand_trust"],
+    label: "Brand Trust",
+    description: "Credibility and trustworthiness of the message and brand",
+    type: "score",
+    scale: { min: 0, max: 10 },
+    defaultSelected: true,
+    defaultWeight: 1,
+    icon: {
+      component: Shield,
+      color: "text-emerald-600",
+      bgColor: "bg-emerald-100 dark:bg-emerald-900/30",
+    },
+  },
+  {
+    id: "intent_to_action",
+    backendKeys: ["purchase_intent", "intent_to_action"],
+    label: "Request/Prescribe Intent",
+    description: "Likelihood to request (patients) or prescribe (HCPs)",
+    type: "score",
+    scale: { min: 0, max: 10 },
+    defaultSelected: true,
+    defaultWeight: 1,
+    icon: {
+      component: Target,
+      color: "text-amber-600",
+      bgColor: "bg-amber-100 dark:bg-amber-900/30",
+    },
+  },
+  {
+    id: "key_concerns",
+    backendKeys: ["key_concerns", "key_concern_flagged"],
+    label: "Key Concerns",
+    description: "Barriers and objections identified",
+    type: "flag",
+    scale: { min: 0, max: 1 },
+    defaultSelected: false,
+    defaultWeight: 1,
+    icon: {
+      component: AlertCircle,
+      color: "text-red-600",
+      bgColor: "bg-red-100 dark:bg-red-900/30",
+    },
+  },
+]
+
+const registryById = new Map(metricRegistry.map((metric) => [metric.id, metric]))
+const registryByBackendKey = new Map<AnalyzedMetricKey | string, MetricDefinition>()
+metricRegistry.forEach((metric) => {
+  metric.backendKeys.forEach((key) => registryByBackendKey.set(key, metric))
+})
+
+export function getMetricById(id: FrontendMetricId | string): MetricDefinition | undefined {
+  return registryById.get(id as FrontendMetricId)
+}
+
+export function getMetricByBackendKey(key: string): MetricDefinition | undefined {
+  return registryByBackendKey.get(key)
+}
+
+export function normalizeBackendMetricKey(key: string): AnalyzedMetricKey {
+  const match = getMetricByBackendKey(key)
+  return match?.backendKeys[0] ?? (key as AnalyzedMetricKey)
+}
+
+export function mapFrontendMetricToBackend(frontendId: FrontendMetricId): AnalyzedMetricKey {
+  const metric = getMetricById(frontendId)
+  return metric?.backendKeys[0] ?? (frontendId as AnalyzedMetricKey)
+}
+
+export function mapBackendMetricToFrontend(backendKey: string): FrontendMetricId | string {
+  const metric = getMetricByBackendKey(backendKey)
+  return metric?.id ?? backendKey
+}

--- a/frontend/src/pages/SimulationHub.tsx
+++ b/frontend/src/pages/SimulationHub.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react"
 import { PersonasAPI, CohortAPI } from "@/lib/api"
+import { metricRegistry } from "@/lib/metricsRegistry"
 import { useNavigate, useLocation } from "react-router-dom"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -54,49 +55,6 @@ interface Persona {
   specialty?: string | null
 }
 
-const availableMetrics = [
-  {
-    id: "emotional_response",
-    label: "Emotional Response",
-    description: "Primary emotional reaction and sentiment toward messaging",
-    icon: Brain,
-    color: "text-violet-600",
-    bgColor: "bg-violet-100 dark:bg-violet-900/30",
-  },
-  {
-    id: "message_clarity",
-    label: "Message Clarity",
-    description: "How well they understand the key messages",
-    icon: MessageSquare,
-    color: "text-blue-600",
-    bgColor: "bg-blue-100 dark:bg-blue-900/30",
-  },
-  {
-    id: "brand_trust",
-    label: "Brand Trust",
-    description: "Credibility and trustworthiness of the message and brand",
-    icon: Shield,
-    color: "text-emerald-600",
-    bgColor: "bg-emerald-100 dark:bg-emerald-900/30",
-  },
-  {
-    id: "intent_to_action",
-    label: "Request/Prescribe Intent",
-    description: "Likelihood to request (patients) or prescribe (HCPs)",
-    icon: Target,
-    color: "text-amber-600",
-    bgColor: "bg-amber-100 dark:bg-amber-900/30",
-  },
-  {
-    id: "key_concerns",
-    label: "Key Concerns",
-    description: "Barriers and objections identified",
-    icon: AlertCircle,
-    color: "text-red-600",
-    bgColor: "bg-red-100 dark:bg-red-900/30",
-  },
-]
-
 const SAMPLE_MESSAGES = [
   "Introducing our new diabetes management solution with 24/7 glucose monitoring",
   "Experience relief from chronic pain with our breakthrough therapy",
@@ -120,7 +78,16 @@ export function SimulationHub() {
   const navigate = useNavigate()
   const [personas, setPersonas] = useState<Persona[]>([])
   const [selectedPersonas, setSelectedPersonas] = useState<Set<number>>(new Set())
-  const [selectedMetrics, setSelectedMetrics] = useState<Set<string>>(new Set(["emotional_response", "message_clarity"]))
+  const [metricSelections, setMetricSelections] = useState<Record<string, { selected: boolean; weight?: number }>>(() => {
+    return metricRegistry.reduce<Record<string, { selected: boolean; weight?: number }>>((acc, metric) => {
+      acc[metric.id] = { selected: !!metric.defaultSelected, weight: metric.defaultWeight ?? 1 }
+      return acc
+    }, {})
+  })
+  const selectedMetrics = useMemo(
+    () => new Set(Object.entries(metricSelections).filter(([, config]) => config.selected).map(([id]) => id)),
+    [metricSelections],
+  )
   const [stimulusText, setStimulusText] = useState("")
   const [stimulusImages, setStimulusImages] = useState<File[]>([])
   const [imagePreviews, setImagePreviews] = useState<string[]>([])
@@ -142,6 +109,7 @@ export function SimulationHub() {
   const [isRecruiting, setIsRecruiting] = useState(false)
   const [isVariant, setIsVariant] = useState(false)
   const [originalMessage, setOriginalMessage] = useState("")
+  const [showMetricWeights, setShowMetricWeights] = useState(false)
 
   // Handle pre-filled message from Analytics page (for message variants)
   const location = useLocation()
@@ -428,13 +396,30 @@ export function SimulationHub() {
   }
 
   const toggleMetric = (id: string) => {
-    const newSelected = new Set(selectedMetrics)
-    if (newSelected.has(id)) {
-      newSelected.delete(id)
-    } else {
-      newSelected.add(id)
-    }
-    setSelectedMetrics(newSelected)
+    setMetricSelections((prev) => {
+      const current = prev[id] || { selected: false, weight: metricRegistry.find((m) => m.id === id)?.defaultWeight ?? 1 }
+      return {
+        ...prev,
+        [id]: {
+          ...current,
+          selected: !current.selected,
+          weight: current.weight ?? metricRegistry.find((m) => m.id === id)?.defaultWeight ?? 1,
+        },
+      }
+    })
+  }
+
+  const updateMetricWeight = (id: string, weight: number) => {
+    const defaultWeight = metricRegistry.find((m) => m.id === id)?.defaultWeight ?? 1
+    const safeWeight = Number.isFinite(weight) ? weight : defaultWeight
+    setMetricSelections((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        selected: prev[id]?.selected ?? true,
+        weight: safeWeight,
+      },
+    }))
   }
 
   const handleImageUpload = (files: FileList | null) => {
@@ -494,8 +479,16 @@ export function SimulationHub() {
     try {
       // Create FormData for file upload
       const formData = new FormData()
+      const selectedMetricIds = Array.from(selectedMetrics)
+      const metricWeights = selectedMetricIds.reduce<Record<string, number>>((acc, id) => {
+        const selection = metricSelections[id]
+        acc[id] = selection?.weight ?? metricRegistry.find((m) => m.id === id)?.defaultWeight ?? 1
+        return acc
+      }, {})
+
       formData.append("persona_ids", JSON.stringify(Array.from(selectedPersonas)))
-      formData.append("metrics", JSON.stringify(Array.from(selectedMetrics)))
+      formData.append("metrics", JSON.stringify(selectedMetricIds))
+      formData.append("metric_weights", JSON.stringify(metricWeights))
       formData.append("content_type", contentType)
 
       if (hasText) {
@@ -510,6 +503,7 @@ export function SimulationHub() {
       console.log("🚀 Sending request with FormData:", {
         persona_ids: formData.get("persona_ids"),
         metrics: formData.get("metrics"),
+        metric_weights: formData.get("metric_weights"),
         content_type: formData.get("content_type"),
         stimulus_text: formData.get("stimulus_text"),
         stimulus_images_count: stimulusImages.length,
@@ -1401,15 +1395,28 @@ export function SimulationHub() {
                     <BarChart3 className="h-4 w-4 text-gray-500" />
                     Analysis Metrics
                   </Label>
-                  <span className="text-sm text-gray-500">
-                    {selectedMetrics.size} of {availableMetrics.length} selected
-                  </span>
+                  <div className="flex items-center gap-3">
+                    <Button
+                      variant={showMetricWeights ? "secondary" : "ghost"}
+                      size="sm"
+                      className="h-8"
+                      onClick={() => setShowMetricWeights((prev) => !prev)}
+                    >
+                      <Gauge className="h-4 w-4 mr-1" />
+                      {showMetricWeights ? "Hide Weights" : "Set Weights"}
+                    </Button>
+                    <span className="text-sm text-gray-500">
+                      {selectedMetrics.size} of {metricRegistry.length} selected
+                    </span>
+                  </div>
                 </div>
                 <div className="grid gap-3 md:grid-cols-2">
-                  {availableMetrics.map((metric) => {
+                  {metricRegistry.map((metric) => {
                     const isSelected = selectedMetrics.has(metric.id)
                     const label = metric.id === "intent_to_action" ? intentLabel : metric.label
                     const description = metric.id === "intent_to_action" ? intentDescription : metric.description
+                    const icon = metric.icon?.component
+                    const weightValue = metricSelections[metric.id]?.weight ?? metric.defaultWeight ?? 1
                     return (
                       <div
                         key={metric.id}
@@ -1427,15 +1434,34 @@ export function SimulationHub() {
                               onClick={(e) => e.stopPropagation()}
                               className="mt-1"
                             />
-                            <div className={`p-2 rounded-lg ${metric.bgColor}`}>
-                              <metric.icon className={`h-4 w-4 ${metric.color}`} />
-                            </div>
+                            {icon && (
+                              <div className={`p-2 rounded-lg ${metric.icon.bgColor}`}>
+                                <icon className={`h-4 w-4 ${metric.icon.color}`} />
+                              </div>
+                            )}
                             <div className="flex-1">
                               <div className="flex items-center gap-2">
                                 <span className="font-medium text-gray-900 dark:text-gray-100">{label}</span>
                                 {isSelected && <CheckCircle2 className="h-4 w-4 text-primary" />}
                               </div>
                               <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">{description}</p>
+                              {isSelected && showMetricWeights && (
+                                <div className="mt-3 flex items-center gap-2">
+                                  <Label htmlFor={`${metric.id}-weight`} className="text-xs text-gray-500">
+                                    Weight
+                                  </Label>
+                                  <Input
+                                    id={`${metric.id}-weight`}
+                                    type="number"
+                                    min={0}
+                                    step={0.1}
+                                    value={weightValue}
+                                    onClick={(e) => e.stopPropagation()}
+                                    onChange={(e) => updateMetricWeight(metric.id, Number(e.target.value))}
+                                    className="w-24 h-9"
+                                  />
+                                </div>
+                              )}
                             </div>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- introduce a shared metric registry with metadata, defaults, and weights used throughout SimulationHub
- send selected metrics and weights to cohort analysis and render analytics/export views dynamically from returned metrics
- normalize metric keys/labels through the registry within analytics helpers and CSV export utilities

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952309136488332a3b3841158572532)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> - Add `metricsRegistry` with metadata (ids, backendKeys, labels, types, scales, defaults, icons) and helpers to map/normalize metric keys.
> 
> **SimulationHub**
> - Replace hardcoded metrics with `metricRegistry`; track selections and optional weights; toggle UI to edit weights.
> - Send `metrics` and `metric_weights` with analysis request (multipart), alongside persona ids/content.
> 
> **Analytics UI**
> - Dynamically derive analyzed metric definitions from results using normalization and registry.
> - Render summary cards, table columns, badges, and per-metric scales/formatting (incl. sentiment descriptors) based on definitions.
> - Compute progress/colors using metric-specific scales.
> 
> **Exports/Helpers**
> - `exportUtils`: build CSV headers/rows from metric definitions; gracefully handle arrays/strings; normalize backend keys.
> - `analytics.ts`: remove hardcoded mappings; expose registry-based label/scale helpers and sentiment backends list; keep score/trend utilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24317c9366dc481b5ade0a0cf8cba5d36d133966. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->