### PR TITLE
Add cohort questions and surface qualitative answers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -99,7 +99,8 @@ def transform_to_frontend_format(backend_response: dict) -> dict:
             'avatar_url': response.get('avatar_url'),
             'persona_type': response.get('persona_type'),
             'reasoning': reasoning,
-            'responses': responses
+            'responses': responses,
+            'answers': response.get('answers')
         })
 
     backend_stats = backend_response.get('summary_statistics', {}) or {}
@@ -117,6 +118,7 @@ def transform_to_frontend_format(backend_response: dict) -> dict:
         'cohort_size': backend_response.get('cohort_size', 0),
         'stimulus_text': backend_response.get('stimulus_text', ''),
         'metrics_analyzed': backend_response.get('metrics_analyzed', []),
+        'questions': backend_response.get('questions'),
         'individual_responses': transformed_responses,
         'summary_statistics': summary_stats,
         'insights': backend_response.get('insights', []),
@@ -527,7 +529,8 @@ async def analyze_cohort(request: schemas.CohortAnalysisRequest, db: Session = D
             persona_ids=request.persona_ids,
             stimulus_text=request.stimulus_text,
             metrics=request.metrics,
-            db=db
+            db=db,
+            questions=request.questions
         )
         
         # Save simulation data

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -84,17 +84,20 @@ class CohortAnalysisRequest(BaseModel):
     persona_ids: List[int]
     stimulus_text: str
     metrics: List[str]
+    questions: Optional[List[str]] = None
 
 class PersonaResponse(BaseModel):
     persona_id: int
     persona_name: str
     responses: Dict[str, Any]
     reasoning: str
+    answers: Optional[List[str]] = None
 
 class CohortAnalysisResponse(BaseModel):
     cohort_size: int
     stimulus_text: str
     metrics_analyzed: List[str]
+    questions: Optional[List[str]] = None
     individual_responses: List[PersonaResponse]
     summary_statistics: Dict[str, Any]
     insights: List[str]

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -259,6 +259,7 @@ export function Analytics() {
     cohort_size,
     stimulus_text,
     metrics_analyzed,
+    questions,
     individual_responses,
     summary_statistics,
     insights,
@@ -668,6 +669,73 @@ export function Analytics() {
                   </div>
                 ))}
               </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {questions && questions.length > 0 && (
+          <Card className="mb-8 border-0 shadow-2xl backdrop-blur-sm bg-white/90 dark:bg-gray-900/90">
+            <CardHeader className="bg-gradient-to-r from-blue-500/10 to-indigo-500/10 rounded-t-xl">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-3">
+                  <div className="p-2.5 bg-gradient-to-br from-blue-500 to-indigo-500 rounded-xl">
+                    <MessageSquare className="h-5 w-5 text-white" />
+                  </div>
+                  <div>
+                    <CardTitle className="text-xl">Qualitative Responses</CardTitle>
+                    <CardDescription>Persona answers to your custom questions</CardDescription>
+                  </div>
+                </div>
+                <Badge className="bg-blue-100 text-blue-800 border-blue-200">Q&A</Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-6 space-y-4">
+              {questions.map((question, qIndex) => {
+                const answersForQuestion = individual_responses?.map((response) => ({
+                  persona: response.persona_name,
+                  answer: response.answers?.[qIndex]
+                })) || []
+                const answeredCount = answersForQuestion.filter((a) => a.answer).length
+
+                return (
+                  <div
+                    key={qIndex}
+                    className="rounded-xl border border-gray-200 dark:border-gray-700 p-4 bg-gray-50 dark:bg-gray-900"
+                  >
+                    <div className="flex items-start justify-between gap-3 mb-3">
+                      <div className="flex items-start gap-2">
+                        <Badge variant="outline" className="mt-0.5">Q{qIndex + 1}</Badge>
+                        <div>
+                          <p className="font-semibold text-gray-900 dark:text-gray-100">{question}</p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            {answeredCount} response
+                            {answeredCount === 1 ? '' : 's'} collected
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="grid gap-3 md:grid-cols-2">
+                      {answersForQuestion.map((entry, idx) => (
+                        <div
+                          key={`${qIndex}-${idx}`}
+                          className="p-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm"
+                        >
+                          <div className="flex items-center justify-between mb-2">
+                            <span className="text-sm font-semibold text-gray-800 dark:text-gray-100">
+                              {entry.persona}
+                            </span>
+                            <Badge variant="secondary" className="text-xs">Persona</Badge>
+                          </div>
+                          <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+                            {entry.answer || 'No answer provided.'}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )
+              })}
             </CardContent>
           </Card>
         )}

--- a/frontend/src/pages/SimulationHub.tsx
+++ b/frontend/src/pages/SimulationHub.tsx
@@ -105,6 +105,7 @@ const SAMPLE_MESSAGES = [
 
 const DEFAULT_AGE_RANGE: [number, number] = [18, 100]
 const PERSONA_TYPES = ["HCP", "Patient"] as const
+const MAX_QUESTIONS = 5
 
 type PersonaType = (typeof PERSONA_TYPES)[number]
 
@@ -125,6 +126,7 @@ export function SimulationHub() {
   const [stimulusImages, setStimulusImages] = useState<File[]>([])
   const [imagePreviews, setImagePreviews] = useState<string[]>([])
   const [contentType, setContentType] = useState<"text" | "image" | "both">("text")
+  const [questions, setQuestions] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const [analyzing, setAnalyzing] = useState(false)
   const [searchTerm, setSearchTerm] = useState("")
@@ -458,6 +460,22 @@ export function SimulationHub() {
     setStimulusImages((prev) => [...prev, ...newImages])
   }
 
+  const addQuestion = () => {
+    if (questions.length >= MAX_QUESTIONS) {
+      alert(`You can add up to ${MAX_QUESTIONS} questions.`)
+      return
+    }
+    setQuestions((prev) => [...prev, ""])
+  }
+
+  const updateQuestion = (index: number, value: string) => {
+    setQuestions((prev) => prev.map((q, i) => (i === index ? value : q)))
+  }
+
+  const removeQuestion = (index: number) => {
+    setQuestions((prev) => prev.filter((_, i) => i !== index))
+  }
+
   const removeImage = (index: number) => {
     setStimulusImages((prev) => prev.filter((_, i) => i !== index))
     setImagePreviews((prev) => prev.filter((_, i) => i !== index))
@@ -466,6 +484,18 @@ export function SimulationHub() {
   const handleRunAnalysis = async () => {
     if (selectedPersonas.size === 0) {
       alert("Please select at least one persona")
+      return
+    }
+
+    const trimmedQuestions = questions.map((q) => q.trim()).filter((q) => q.length > 0)
+
+    if (questions.some((q) => q.trim().length === 0) && questions.length > 0) {
+      alert("Please fill in all questions or remove empty ones.")
+      return
+    }
+
+    if (trimmedQuestions.length > MAX_QUESTIONS) {
+      alert(`Please limit qualitative questions to ${MAX_QUESTIONS}.`)
       return
     }
     if (selectedMetrics.size === 0) {
@@ -492,30 +522,51 @@ export function SimulationHub() {
 
     setAnalyzing(true)
     try {
-      // Create FormData for file upload
-      const formData = new FormData()
-      formData.append("persona_ids", JSON.stringify(Array.from(selectedPersonas)))
-      formData.append("metrics", JSON.stringify(Array.from(selectedMetrics)))
-      formData.append("content_type", contentType)
+      let response
 
-      if (hasText) {
-        formData.append("stimulus_text", stimulusText)
+      if (contentType === "text" && stimulusImages.length === 0) {
+        const payload: Record<string, any> = {
+          persona_ids: Array.from(selectedPersonas),
+          stimulus_text: stimulusText,
+          metrics: Array.from(selectedMetrics),
+        }
+
+        if (trimmedQuestions.length > 0) {
+          payload.questions = trimmedQuestions
+        }
+
+        response = await CohortAPI.analyze(payload)
+      } else {
+        // Create FormData for file upload
+        const formData = new FormData()
+        formData.append("persona_ids", JSON.stringify(Array.from(selectedPersonas)))
+        formData.append("metrics", JSON.stringify(Array.from(selectedMetrics)))
+        formData.append("content_type", contentType)
+
+        if (hasText) {
+          formData.append("stimulus_text", stimulusText)
+        }
+
+        if (trimmedQuestions.length > 0) {
+          formData.append("questions", JSON.stringify(trimmedQuestions))
+        }
+
+        stimulusImages.forEach((image) => {
+          formData.append(`stimulus_images`, image)
+        })
+
+        // Note: This will require backend API updates to handle multipart/form-data
+        console.log("🚀 Sending request with FormData:", {
+          persona_ids: formData.get("persona_ids"),
+          metrics: formData.get("metrics"),
+          content_type: formData.get("content_type"),
+          stimulus_text: formData.get("stimulus_text"),
+          stimulus_images_count: stimulusImages.length,
+          questions: formData.get("questions"),
+        })
+
+        response = await CohortAPI.analyze(formData)
       }
-
-      stimulusImages.forEach((image) => {
-        formData.append(`stimulus_images`, image)
-      })
-
-      // Note: This will require backend API updates to handle multipart/form-data
-      console.log("🚀 Sending request with FormData:", {
-        persona_ids: formData.get("persona_ids"),
-        metrics: formData.get("metrics"),
-        content_type: formData.get("content_type"),
-        stimulus_text: formData.get("stimulus_text"),
-        stimulus_images_count: stimulusImages.length,
-      })
-
-      const response = await CohortAPI.analyze(formData)
 
       console.log("✅ Received response:", {
         responseType: typeof response,
@@ -1316,6 +1367,53 @@ export function SimulationHub() {
                         Sample {index + 1}
                       </Button>
                     ))}
+                  </div>
+
+                  <div className="mt-4 rounded-xl border border-dashed border-gray-300 dark:border-gray-700 p-4 bg-gray-50/60 dark:bg-gray-900/50">
+                    <div className="flex items-center justify-between mb-3">
+                      <div>
+                        <p className="text-sm font-semibold text-gray-800 dark:text-gray-100 flex items-center gap-2">
+                          <MessageSquare className="h-4 w-4 text-primary" />
+                          Optional Qualitative Questions
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          Ask up to {MAX_QUESTIONS} custom questions and get persona-specific answers.
+                        </p>
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={addQuestion}
+                        disabled={questions.length >= MAX_QUESTIONS}
+                        className="flex items-center gap-1"
+                      >
+                        <Plus className="h-4 w-4" />
+                        Add Question
+                      </Button>
+                    </div>
+
+                    {questions.length === 0 && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 italic">
+                        No questions added yet.
+                      </p>
+                    )}
+
+                    <div className="space-y-3">
+                      {questions.map((question, index) => (
+                        <div key={index} className="flex items-start gap-2">
+                          <Badge variant="outline" className="mt-2">Q{index + 1}</Badge>
+                          <Input
+                            value={question}
+                            placeholder="e.g., What would make this message more convincing for you?"
+                            onChange={(e) => updateQuestion(index, e.target.value)}
+                            className="flex-1"
+                          />
+                          <Button variant="ghost" size="icon" onClick={() => removeQuestion(index)}>
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 </div>
               )}

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -49,6 +49,7 @@ export interface IndividualResponseRow {
   persona_type?: string;
   reasoning: string;
   responses: PersonaResponseScores;
+  answers?: string[];
 }
 
 export interface ActionableSuggestion {
@@ -60,6 +61,7 @@ export interface AnalysisResults {
   cohort_size: number;
   stimulus_text: string;
   metrics_analyzed: AnalyzedMetricKey[];
+  questions?: string[];
   individual_responses: IndividualResponseRow[];
   summary_statistics: SummaryStatistics;
   insights?: string[];


### PR DESCRIPTION
## Summary
- add optional cohort questions/answers to backend schemas, processing, and response transformation
- allow simulation requests to include qualitative questions and render answers in analytics
- extend Simulation Hub with repeatable question inputs and validation before analysis

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952309d45ac833296d70adc84fc4ddb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional qualitative Q&A to cohort analysis, flowing from request to UI.
> 
> - Backend: `cohort_engine.create_cohort_analysis_prompt` now accepts `questions`, embeds them in the prompt, and expects `answers` in JSON; `analyze_persona_response` normalizes and returns `answers`; `run_cohort_analysis` accepts `questions` and includes them and per-persona `answers` in results
> - API/Schemas: Extend `CohortAnalysisRequest`, `PersonaResponse`, and `CohortAnalysisResponse` with `questions`/`answers`; `/cohorts/analyze` passes `request.questions`; response transformer adds `questions` and per-persona `answers`
> - Frontend: `SimulationHub` adds repeatable question inputs (max 5) with validation and request wiring; `Analytics` displays a new "Qualitative Responses" section showing per-question, per-persona answers; types (`AnalysisResults`, `IndividualResponseRow`) updated to include `questions`/`answers`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12d9fa33e3711b1c5595118f53f9bd2cd3e2fcd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->