### PR TITLE
Add composite analytics scoring and custom Q&A views

### DIFF
--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -46,6 +46,21 @@ export function normalizeMetricKey(metric: string): string {
   return normalized[metric] || metric;
 }
 
+export function normalizeMetricScore(metric: string, score: number): number {
+  const key = normalizeMetricKey(metric);
+  if (key === 'sentiment') {
+    // Convert -1 to 1 sentiment into a 0-10 scale
+    return ((score + 1) / 2) * 10;
+  }
+  return score;
+}
+
+export function formatMetricLabel(metric: string): string {
+  return normalizeMetricKey(metric)
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 export function computeScoreColor(score: number, max: number = 10): string {
   const percentage = (score / max) * 100;
   if (percentage >= 70) return 'text-emerald-600';

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -28,6 +28,7 @@ export interface SummaryStatistics {
   brand_trust_avg?: number;
   trust_in_brand_avg?: number;   // legacy alias
   message_clarity_avg?: number;
+  [key: string]: unknown;
 }
 
 export interface PersonaResponseScores {
@@ -40,6 +41,9 @@ export interface PersonaResponseScores {
   message_clarity?: number;
   key_concern_flagged?: string | boolean | number;
   key_concerns?: string | boolean | number;  // Support both naming conventions
+  custom_questions?: CustomQuestionResponse[];
+  custom_question_answers?: Record<string, string>;
+  [key: string]: unknown;
 }
 
 export interface IndividualResponseRow {
@@ -49,11 +53,17 @@ export interface IndividualResponseRow {
   persona_type?: string;
   reasoning: string;
   responses: PersonaResponseScores;
+  custom_questions?: CustomQuestionResponse[];
 }
 
 export interface ActionableSuggestion {
   suggestion: string;
   reasoning: string;
+}
+
+export interface CustomQuestionResponse {
+  question: string;
+  answer: string;
 }
 
 export interface AnalysisResults {
@@ -66,6 +76,8 @@ export interface AnalysisResults {
   suggestions?: ActionableSuggestion[];
   preamble?: string;
   created_at: string;
+  metric_weights?: Record<string, number>;
+  custom_questions?: CustomQuestionResponse[];
 }
 
 export type TrendDirection = 'up' | 'down' | 'neutral';


### PR DESCRIPTION
## Summary
- add metric weighting controls, composite score card, and per-persona composite column normalized for sentiment
- render analytics cards, charts, tables, and exports dynamically from metrics_analyzed values
- surface custom question responses through an aggregated card and per-persona Q&A modal

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952309ff6f88332bdeac6b7c60d46be)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Analytics UI enhancements**
> 
> - Adds `normalizeMetricScore` and `formatMetricLabel` in `lib/analytics.ts` to standardize metric scales (e.g., sentiment to 0–10) and labels
> - Introduces "Metric Performance Overview" with Recharts `BarChart` and `RadarChart` showing normalized averages
> - Surfaces custom questions via a new aggregated card and a persona-specific Q&A `Dialog`
> 
> **Data/model and utils**
> 
> - Expands types: `CustomQuestionResponse`, `metric_weights`, `custom_questions`, and index signatures on `SummaryStatistics`/`PersonaResponseScores`
> - Enhances CSV export helpers with flexible metric key resolution (`getMetricValue`) and keeps `copyToClipboard` utility
> 
> **Misc**
> 
> - Minor state refactors and UI polish across `Analytics.tsx` (icons, layouts, progress/colors)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6616e0e83a7a0431e5816e78b36d074be6d1f5dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->