### PR TITLE
Dynamic persona testing metrics

### DIFF
--- a/backend/app/cohort_engine.py
+++ b/backend/app/cohort_engine.py
@@ -630,7 +630,8 @@ def run_cohort_analysis(
         "insights": llm_generated_data.get("cumulative_insights", []),
         "suggestions": llm_generated_data.get("actionable_suggestions", []),
         "preamble": preamble_text,
-        "created_at": datetime.now().isoformat()
+        "created_at": datetime.now().isoformat(),
+        "metric_weights": metric_weights or {}
     }
     
     return final_analysis

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -142,7 +142,8 @@ def transform_to_frontend_format(backend_response: dict) -> dict:
         'insights': backend_response.get('insights', []),
         'suggestions': backend_response.get('suggestions', []),
         'preamble': backend_response.get('preamble') or backend_response.get('content_summary', ''),
-        'created_at': backend_response.get('created_at', '')
+        'created_at': backend_response.get('created_at', ''),
+        'metric_weights': backend_response.get('metric_weights')
     }
 
 


### PR DESCRIPTION
Implement composite score calculation and display to enhance persona test results.

This PR completes the "Enhanced Results" section of the dynamic metrics specification by adding an overall weighted composite score card and a per-persona composite score column to the analytics page. This provides users with a clear, aggregated view of performance based on selected metrics and their weights.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbb2b7c9-92cd-49fe-bdf6-c3635e1100df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cbb2b7c9-92cd-49fe-bdf6-c3635e1100df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

