### PR TITLE
Add vector storage metadata to brand document uploads

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -59,7 +59,7 @@ class Brand(Base):
 
 class BrandDocument(Base):
     __tablename__ = "brand_documents"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     brand_id = Column(Integer, index=True)
     filename = Column(String)
@@ -67,4 +67,7 @@ class BrandDocument(Base):
     category = Column(String)
     summary = Column(Text, nullable=True)
     extracted_insights = Column(JSON, nullable=True)
+    vector_store_id = Column(String, nullable=True)
+    chunk_size = Column(Integer, nullable=True)
+    chunk_ids = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -172,6 +172,9 @@ class BrandDocumentBase(BaseModel):
     category: str
     summary: Optional[str] = None
     extracted_insights: Optional[List[BrandInsight]] = None
+    vector_store_id: Optional[str] = None
+    chunk_size: Optional[int] = None
+    chunk_ids: Optional[List[str]] = None
 
 class BrandDocumentCreate(BrandDocumentBase):
     filepath: str


### PR DESCRIPTION
## Summary
- add vector store and chunk metadata fields to brand document models and schemas
- chunk uploaded brand document text, call OpenAI vector store and embedding APIs when available, and persist returned identifiers
- extend startup migrations to add the new brand document columns safely

## Testing
- python -m compileall backend/app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e5a4a6f0833285cc7f3f7f4df454)