### PR TITLE
Add OpenAI vector store ingestion for brand documents

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1105,9 +1105,12 @@ async def upload_brand_document(
         brand_id=brand_id,
         filename=safe_filename,
         chunk_size=chunk_size,
+        insights=extracted_insights,
     )
 
     # Create or replace document record while cleaning up any stale vectors
+    chunk_size_value = chunk_size if (chunks or vector_store_id) else None
+
     doc_create = schemas.BrandDocumentCreate(
         brand_id=brand_id,
         filename=safe_filename,
@@ -1116,7 +1119,7 @@ async def upload_brand_document(
         summary=text[:200] + "..." if text else "No text extracted",
         extracted_insights=extracted_insights,
         vector_store_id=vector_store_id,
-        chunk_size=chunk_size if chunks else None,
+        chunk_size=chunk_size_value,
         chunk_ids=chunk_ids or None,
     )
 


### PR DESCRIPTION
## Summary
- populate OpenAI vector stores with MBT insight payloads (falling back to text chunks) when brand documents are uploaded
- include metadata for brand, source document, and segments to support filtered retrieval and clean up stores on failure
- persist chunk size metadata when vectorization occurs even without raw chunks

## Testing
- python -m compileall backend/app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e2b61a988332bb6d8b7207c24e0f)