### PR TITLE
Add transcript ingestion for persona suggestions

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,15 @@ export const PersonasAPI = {
   enrichFromBrand: (id: number, payload: { brand_id: number; target_segment?: string; target_fields?: string[] }) =>
     api.post(`/personas/${id}/enrich-from-brand`, payload).then(r => r.data),
   regenerateAvatar: (id: number) => api.post(`/personas/${id}/regenerate-avatar`).then(r => r.data),
+  extractFromTranscript: (payload: FormData | { transcript_text: string }) => {
+    if (payload instanceof FormData) {
+      return api.post('/personas/from-transcript', payload).then(r => r.data)
+    }
+
+    const formData = new FormData();
+    formData.append('transcript_text', payload.transcript_text);
+    return api.post('/personas/from-transcript', formData).then(r => r.data)
+  },
 };
 
 export interface BrandInsight {


### PR DESCRIPTION
## Summary
- add a `/personas/from-transcript` endpoint that ingests transcript text or files and returns enriched persona suggestions with confidence and evidence
- extend persona NLP helpers to carry evidence for suggested fields and expose transcript analysis through the client API
- update the create persona page to upload/paste transcripts, preview AI-labeled suggestions, and apply them to the manual form

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69544d2367488332bfc77974bd34085b)