### PR TITLE
Handle object persona JSON in detail modal

### DIFF
--- a/frontend/src/components/PersonaDetailModal.tsx
+++ b/frontend/src/components/PersonaDetailModal.tsx
@@ -28,8 +28,10 @@ export function PersonaDetailModal({ isOpen, onClose, persona }: PersonaDetailMo
 
   const resetPersonaState = () => {
     if (!persona) return;
+    const rawData = persona.full_persona_json;
     try {
-      setEditablePersona(JSON.parse(persona.full_persona_json));
+      const parsed = typeof rawData === 'string' ? JSON.parse(rawData) : rawData;
+      setEditablePersona(parsed || {});
     } catch {
       setEditablePersona({});
     }
@@ -136,7 +138,10 @@ export function PersonaDetailModal({ isOpen, onClose, persona }: PersonaDetailMo
         brand_id: selectedBrandId,
         target_segment: targetSegment || undefined
       })
-      setEditablePersona(JSON.parse(response.full_persona_json))
+      const enrichedData = typeof response.full_persona_json === 'string'
+        ? JSON.parse(response.full_persona_json)
+        : response.full_persona_json
+      setEditablePersona(enrichedData || {})
       alert("Persona enriched with brand insights.")
     } catch (err) {
       console.error("Brand enrichment failed", err)


### PR DESCRIPTION
## Summary
- handle persona modal parsing when full_persona_json is already an object
- ensure brand enrichment responses are parsed safely before updating state

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69546536af5c83328283b15bc1a7c247)