### PR TITLE
Add guided sidebar user flow panel

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,7 +11,8 @@ import {
   Library,
   Sparkles,
   ChevronRight,
-  PieChart
+  PieChart,
+  CheckCircle2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -63,6 +64,34 @@ const navigation = [
     description: 'Insights & reports',
     href: '/analytics',
     icon: BarChart3,
+  },
+];
+
+const guidedFlow = [
+  {
+    title: 'Start with context',
+    description: 'Scan the dashboard for recent engagement shifts.',
+    href: '/',
+  },
+  {
+    title: 'Generate & align personas',
+    description: 'Create personas, then refine them with the builder.',
+    href: '/create-persona',
+  },
+  {
+    title: 'Check coverage & gaps',
+    description: 'Use Persona Coverage to spot priority segments.',
+    href: '/coverage',
+  },
+  {
+    title: 'Run simulations',
+    description: 'Test narratives and sequencing in Simulation Hub.',
+    href: '/simulation',
+  },
+  {
+    title: 'Share outcomes',
+    description: 'Publish insights to Analytics for stakeholders.',
+    href: '/analytics',
   },
 ];
 
@@ -159,6 +188,41 @@ export function Layout() {
             })}
           </div>
         </nav>
+
+        {/* Guided user flow */}
+        <div className="px-3 pb-4">
+          <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-4 shadow-inner">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-white/60">Suggested flow</p>
+                <p className="text-sm font-medium text-white">Tell the persona story step by step.</p>
+                <p className="text-xs text-white/60">Follow this sequence to guide new users.</p>
+              </div>
+              <Sparkles className="h-4 w-4 text-white/80" />
+            </div>
+
+            <div className="mt-4 space-y-2">
+              {guidedFlow.map((step, index) => (
+                <Link
+                  to={step.href}
+                  key={step.title}
+                  className="group flex items-start gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-white/10"
+                >
+                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white/10 text-[11px] font-semibold text-white">
+                    {index + 1}
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-semibold text-white">{step.title}</p>
+                      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-300 opacity-0 transition-opacity group-hover:opacity-100" />
+                    </div>
+                    <p className="text-xs text-white/60">{step.description}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
 
         {/* Sidebar Footer - API Status */}
         <div className="p-4 border-t border-white/10">


### PR DESCRIPTION
## Summary
- add a guided flow panel in the sidebar to outline the persona journey
- provide linkable steps with descriptive copy to help users navigate in order
- enhance visual feedback with numbering and hover checkmarks

## Testing
- npm run lint *(warnings from existing hooks dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69550b2c5e988332ab8b45f2a6ef348b)